### PR TITLE
Linting, PII & BI Engine

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,20 @@
+name: CI
+
+on: [push]
+
+jobs:
+  lams_job:
+    runs-on: ubuntu-latest
+    name: LAMS LookML Linter Job
+    steps:
+    - name: Checkout your LookML
+      uses: actions/checkout@v1
+    - name: Setup Node
+      uses: actions/setup-node@v1
+      with:
+        node-version: '16.x'
+    - name: Install LAMS
+      run: npm install -g @looker/look-at-me-sideways@3
+    - name: Run LAMS
+      # See [PRIVACY.md](https://github.com/looker-open-source/look-at-me-sideways/blob/master/PRIVACY.md)
+      run: lams --reporting=no

--- a/explores/jobs.explore.lkml
+++ b/explores/jobs.explore.lkml
@@ -152,7 +152,7 @@ explore: jobs_base {
     view_label: "Job > Stages > Steps"
     relationship: one_to_many
     type: left_outer
-    sql: LEFT JOIN UNNEST(job_stages.steps) AS job_stage_steps WITH OFFSET job_stage_steps_offset ;;
+    sql: LEFT JOIN UNNEST(${job_stages.steps_raw}) AS job_stage_steps WITH OFFSET job_stage_steps_offset ;;
     required_joins: [job_stages]
   }
 

--- a/manifest.lkml
+++ b/manifest.lkml
@@ -2,7 +2,7 @@
 
 constant: CONNECTION {
   # Enter the name of the Looker connection to use
-  value: "looker_app_2"
+  value: "looker_private_demo" #value: "looker_app_2"
   export: override_optional
 }
 
@@ -14,7 +14,7 @@ constant: REGION {
 constant: SCOPE {
   # The table from which jobs data will be sourced, per the options described at https://cloud.google.com/bigquery/docs/information-schema-jobs
   # This block has been tested with PROJECT or ORGANIZATION. Tables for USER and FOLDER are untested as of 2021-04
-  value: "PROJECT"
+  value: "USER" #value: "PROJECT"
   export: override_optional
 }
 constant: BILLING_PROJECT_ID {
@@ -38,3 +38,45 @@ constant: MAX_JOB_LOOKBACK {
   value: "8 HOUR"
   export: override_optional
 }
+
+constant: PII_QUERY_TEXT {
+  # Whether/how to expose strings/numbers that may be embedded in query text or query plans (which might sometimes contain PII)
+  # Valid values are: SHOW, HASH, or HIDE
+  # Invalid values will be treated as HIDE
+  value: "HIDE"
+  export: override_optional
+}
+
+constant: PII_HASH_PADDING {
+  # If your other PII constant specifies the HASH option, you may specify padding to be added before computing the hash, to make the hash
+  # more resistant to pre-computed hash tables
+  value: "oQ4IS2cTmXBN"
+  export: override_optional
+}
+
+#LAMS
+#rule: K7{} # Provide one `primary_key`
+#rule: F1{} # No cross-view fields
+#rule: F2{} # No view-labeled fields
+#rule: F3{} # Count fields filtered
+#rule: F4{} # Description or hidden
+#rule: E1{} # Join with subst'n operator
+#rule: E7{} # Explore label 25-char max
+#rule: T1{} # Triggers use datagroups
+#rule: W1{} # Block indentation
+#
+#rule: mft1 {
+# description: "CONNECTION: If you adapted manifest values for development purposes, ensure they have the expected published default value."
+# match: "$.manifest.constant.CONNECTION.value"
+# expr_rule: (=== ::match "")
+#}
+#rule: mft2 {
+# description: "REGION: If you adapted manifest values for development purposes, ensure they have the expected published default value."
+# match: "$.manifest.constant.REGION.value"
+# expr_rule: (=== ::match "us")
+#}
+#rule: mft3 {
+# description: "SCOPE: If you adapted manifest values for development purposes, ensure they have the expected published default value."
+# match: "$.manifest.constant.SCOPE.value"
+# expr_rule: (=== ::match "PROJECT")
+#}

--- a/manifest.lkml
+++ b/manifest.lkml
@@ -2,7 +2,7 @@
 
 constant: CONNECTION {
   # Enter the name of the Looker connection to use
-  value: "looker_private_demo" #value: ""
+  value: ""
   export: override_optional
 }
 
@@ -14,7 +14,7 @@ constant: REGION {
 constant: SCOPE {
   # The table from which jobs data will be sourced, per the options described at https://cloud.google.com/bigquery/docs/information-schema-jobs
   # This block has been tested with PROJECT or ORGANIZATION. Tables for USER and FOLDER are untested as of 2021-04
-  value: "USER" #value: "PROJECT"
+  value: "PROJECT"
   export: override_optional
 }
 constant: BILLING_PROJECT_ID {
@@ -41,16 +41,9 @@ constant: MAX_JOB_LOOKBACK {
 
 constant: PII_QUERY_TEXT {
   # Whether/how to expose strings/numbers that may be embedded in query text or query plans (which might sometimes contain PII)
-  # Valid values are: SHOW, HASH, or HIDE
+  # Valid values are: SHOW, or HIDE
   # Invalid values will be treated as HIDE
   value: "HIDE"
-  export: override_optional
-}
-
-constant: PII_HASH_PADDING {
-  # If your other PII constant specifies the HASH option, you may specify padding to be added before computing the hash, to make the hash
-  # more resistant to pre-computed hash tables
-  value: "oQ4IS2cTmXBN"
   export: override_optional
 }
 

--- a/manifest.lkml
+++ b/manifest.lkml
@@ -2,7 +2,7 @@
 
 constant: CONNECTION {
   # Enter the name of the Looker connection to use
-  value: "looker_private_demo" #value: "looker_app_2"
+  value: "looker_private_demo" #value: ""
   export: override_optional
 }
 
@@ -59,23 +59,22 @@ constant: PII_HASH_PADDING {
 #rule: F1{} # No cross-view fields
 #rule: F2{} # No view-labeled fields
 #rule: F3{} # Count fields filtered
-#rule: F4{} # Description or hidden
 #rule: E1{} # Join with subst'n operator
 #rule: E7{} # Explore label 25-char max
 #rule: T1{} # Triggers use datagroups
 #
 #rule: mft1 {
-# description: "CONNECTION: If you adapted manifest values for development purposes, ensure they have the expected published default value."
+# description: "CONNECTION: If you adapted the manifest value for dev purposes, ensure it has the expected value to publish, \"\" (or update rule)"
 # match: "$.manifest.constant.CONNECTION.value"
 # expr_rule: (=== ::match "") ;;
 #}
 #rule: mft2 {
-# description: "REGION: If you adapted manifest values for development purposes, ensure they have the expected published default value."
+# description: "REGION: If you adapted the manifest value for dev purposes, ensure it has the expected value to publish, \"us\" (or update rule)"
 # match: "$.manifest.constant.REGION.value"
 # expr_rule: (=== ::match "us") ;;
 #}
 #rule: mft3 {
-# description: "SCOPE: If you adapted manifest values for development purposes, ensure they have the expected published default value."
+# description: "SCOPE: If you adapted the manifest value for dev purposes, ensure it has the expected value to publish, \"PROJECT\" (or update rule)"
 # match: "$.manifest.constant.SCOPE.value"
 # expr_rule: (=== ::match "PROJECT") ;;
 #}

--- a/manifest.lkml
+++ b/manifest.lkml
@@ -55,7 +55,6 @@ constant: PII_HASH_PADDING {
 }
 
 #LAMS
-#rule: K7{} # Provide one `primary_key`
 #rule: F1{} # No cross-view fields
 #rule: F2{} # No view-labeled fields
 #rule: F3{} # Count fields filtered
@@ -64,17 +63,17 @@ constant: PII_HASH_PADDING {
 #rule: T1{} # Triggers use datagroups
 #
 #rule: mft1 {
-# description: "CONNECTION: If you adapted the manifest value for dev purposes, ensure it has the expected value to publish, \"\" (or update rule)"
+# description: "CONNECTION: If you adapted this value for dev purposes, ensure it has the expected value to publish, \"\" (or update rule)"
 # match: "$.manifest.constant.CONNECTION.value"
 # expr_rule: (=== ::match "") ;;
 #}
 #rule: mft2 {
-# description: "REGION: If you adapted the manifest value for dev purposes, ensure it has the expected value to publish, \"us\" (or update rule)"
+# description: "REGION: If you adapted this value for dev purposes, ensure it has the expected value to publish, \"us\" (or update rule)"
 # match: "$.manifest.constant.REGION.value"
 # expr_rule: (=== ::match "us") ;;
 #}
 #rule: mft3 {
-# description: "SCOPE: If you adapted the manifest value for dev purposes, ensure it has the expected value to publish, \"PROJECT\" (or update rule)"
+# description: "SCOPE: If you adapted this value for dev purposes, ensure it has the expected value to publish, \"PROJECT\" (or update rule)"
 # match: "$.manifest.constant.SCOPE.value"
 # expr_rule: (=== ::match "PROJECT") ;;
 #}

--- a/manifest.lkml
+++ b/manifest.lkml
@@ -68,15 +68,15 @@ constant: PII_HASH_PADDING {
 #rule: mft1 {
 # description: "CONNECTION: If you adapted manifest values for development purposes, ensure they have the expected published default value."
 # match: "$.manifest.constant.CONNECTION.value"
-# expr_rule: (=== ::match "")
+# expr_rule: (=== ::match "") ;;
 #}
 #rule: mft2 {
 # description: "REGION: If you adapted manifest values for development purposes, ensure they have the expected published default value."
 # match: "$.manifest.constant.REGION.value"
-# expr_rule: (=== ::match "us")
+# expr_rule: (=== ::match "us") ;;
 #}
 #rule: mft3 {
 # description: "SCOPE: If you adapted manifest values for development purposes, ensure they have the expected published default value."
 # match: "$.manifest.constant.SCOPE.value"
-# expr_rule: (=== ::match "PROJECT")
+# expr_rule: (=== ::match "PROJECT") ;;
 #}

--- a/manifest.lkml
+++ b/manifest.lkml
@@ -63,7 +63,6 @@ constant: PII_HASH_PADDING {
 #rule: E1{} # Join with subst'n operator
 #rule: E7{} # Explore label 25-char max
 #rule: T1{} # Triggers use datagroups
-#rule: W1{} # Block indentation
 #
 #rule: mft1 {
 # description: "CONNECTION: If you adapted manifest values for development purposes, ensure they have the expected published default value."

--- a/marketplace.json
+++ b/marketplace.json
@@ -20,6 +20,10 @@
         "label": "Dataset Location",
         "description": "Example: 'us' or 'eu'"
       },
+      "PII_QUERY_TEXT": {
+        "label": "Possible PII Handling",
+        "description": "Whether/how to expose strings/numbers that may be embedded in query text or query plans (which might sometimes contain PII). Valid values are: SHOW or HIDE."
+      },
       "BILLING_PROJECT_ID": {
         "label": "Billing Project ID",
         "description": "This is used to reference Capacity Commitment data (for flat-rate billing) to compare slot usage against"

--- a/views/columns.view.lkml
+++ b/views/columns.view.lkml
@@ -4,6 +4,7 @@ view: columns {
   measure: count {
     type: count
     drill_fields: [detail*]
+    filters: [column_name: "-NULL"]
   }
 
   dimension: table_catalog {

--- a/views/jobs/job_stage_steps.view.lkml
+++ b/views/jobs/job_stage_steps.view.lkml
@@ -6,6 +6,8 @@ view: job_stage_steps {
     primary_key: yes
     hidden: yes
     sql: ${jobs.job_id} || "-" || CAST(${job_stages.stage_id} AS STRING) || "-" || CAST(job_stage_steps_offset AS STRING) ;;
+    #LAMS
+    #rule_exemptions:{F1:"Parent view references are ok/required for nested field views"}
   }
 
   dimension: kind {}

--- a/views/jobs/job_stages.view.lkml
+++ b/views/jobs/job_stages.view.lkml
@@ -6,6 +6,8 @@ view: job_stages {
     primary_key: yes
     hidden: yes
     sql: ${jobs.job_id} || "-" || CAST(${stage_id} AS STRING) ;;
+    #LAMS
+    #rule_exemptions:{F1:"Parent view references are ok/required for nested field views"}
   }
 
   dimension: stage_id {

--- a/views/jobs/job_stages.view.lkml
+++ b/views/jobs/job_stages.view.lkml
@@ -339,6 +339,11 @@ view: job_stages {
 
   # Dimension Group: Step details {
 
+  dimension: steps_raw {
+    hidden: yes
+    sql: ${TABLE}.steps ;;
+  }
+
   dimension: steps_json {
     group_label: "Steps"
     label: "All Steps (JSON)"
@@ -360,7 +365,7 @@ view: job_stages {
         , "\n"
         ORDER BY s ASC
       )
-      FROM UNNEST(${TABLE}.steps) AS step WITH OFFSET s ) ;;
+      FROM UNNEST(${steps_raw}) AS step WITH OFFSET s ) ;;
     html: <div style="white-space:pre-line">{{value}}</div> ;;
   }
 

--- a/views/jobs/jobs.view.lkml
+++ b/views/jobs/jobs.view.lkml
@@ -259,33 +259,33 @@ view: jobs_base {
     sql: ${spill_to_disk_bytes}>0 ;;
   }
 
-    dimension: bi_engine_mode {
-      hidden: yes # Hiding because this appears to just be a less detailed version of acceleration_mode
-      group_label: "Optimization"
-      label: "BI Engine Mode"
-      description: "e.g., ACCELERATION_MODE_UNSPECIFIED, DISABLED, PARTIAL, FULL"
-      type: string
-      sql:  ${TABLE}.bi_engine_statistics.bi_engine_mode ;;
-      suggestions: ["ACCELERATION_MODE_UNSPECIFIED", "DISABLED", "PARTIAL", "FULL"]
-    }
-    dimension: acceleration_mode {
-      group_label: "Optimization"
-      label: "BI Engine Acceleration Mode"
-      description: "e.g., ACCELERATION_MODE_UNSPECIFIED, DISABLED, PARTIAL, FULL"
-      type: string
-      sql:  ${TABLE}.bi_engine_statistics.acceleration_mode ;;
-      suggestions: ["ACCELERATION_MODE_UNSPECIFIED", "DISABLED", "PARTIAL", "FULL"]
-    }
+  dimension: bi_engine_mode {
+    hidden: yes # Hiding because this appears to just be a less detailed version of acceleration_mode
+    group_label: "Optimization"
+    label: "BI Engine Mode"
+    description: "e.g., ACCELERATION_MODE_UNSPECIFIED, DISABLED, PARTIAL, FULL"
+    type: string
+    sql:  ${TABLE}.bi_engine_statistics.bi_engine_mode ;;
+    suggestions: ["ACCELERATION_MODE_UNSPECIFIED", "DISABLED", "PARTIAL", "FULL"]
+  }
+  dimension: acceleration_mode {
+    group_label: "Optimization"
+    label: "BI Engine Acceleration Mode"
+    description: "e.g., ACCELERATION_MODE_UNSPECIFIED, DISABLED, PARTIAL, FULL"
+    type: string
+    sql:  ${TABLE}.bi_engine_statistics.acceleration_mode ;;
+    suggestions: ["ACCELERATION_MODE_UNSPECIFIED", "DISABLED", "PARTIAL", "FULL"]
+  }
 
-    dimension: bi_engine_reasons {
-      group_label: "Optimization"
-      label: "BI Engine Reasons"
-      description: "List of codes identifying the high-level reasons for no/partial acceleration. See https://cloud.google.com/bigquery/docs/reference/rest/v2/Job#Code"
-      type: string
-      sql: (SELECT STRING_AGG(DISTINCT code,", ") FROM UNNEST(${TABLE}.bi_engine_statistics.bi_engine_reasons)) ;;
-      suggestions: ["CODE_UNSPECIFIED","NO_RESERVATION","INSUFFICIENT_RESERVATION",
-        "UNSUPPORTED_SQL_TEXT", "INPUT_TOO_LARGE", "OTHER_REASON", "TABLE_EXCLUDED"]
-    }
+  dimension: bi_engine_reasons {
+    group_label: "Optimization"
+    label: "BI Engine Reasons"
+    description: "List of codes identifying the high-level reasons for no/partial acceleration. See https://cloud.google.com/bigquery/docs/reference/rest/v2/Job#Code"
+    type: string
+    sql: (SELECT STRING_AGG(DISTINCT code,", ") FROM UNNEST(${TABLE}.bi_engine_statistics.bi_engine_reasons)) ;;
+    suggestions: ["CODE_UNSPECIFIED","NO_RESERVATION","INSUFFICIENT_RESERVATION",
+      "UNSUPPORTED_SQL_TEXT", "INPUT_TOO_LARGE", "OTHER_REASON", "TABLE_EXCLUDED"]
+  }
 
   # }
 

--- a/views/jobs/jobs.view.lkml
+++ b/views/jobs/jobs.view.lkml
@@ -9,6 +9,8 @@ view: jobs {
     sql:
       SELECT *
       FROM `region-@{REGION}`.INFORMATION_SCHEMA.JOBS_BY_@{SCOPE}
+      WHERE creation_time >= {% date_start date.date_filter%}
+        AND creation_time < {% date_end date.date_filter%}
     ;;
   }
 }

--- a/views/jobs/jobs.view.lkml
+++ b/views/jobs/jobs.view.lkml
@@ -52,12 +52,12 @@ view: jobs_base {
     link: {
       label: "Job Lookup Dashboard"
       url: "/dashboards-next/bigquery_information_schema::job_lookup_dashboard?Job%20ID={{ value | encode_uri}}&Created={{date.date_in_filter_format | encode_uri}}"
-      icon_url: "http://www.looker.com/favicon.ico"
+      icon_url: "/favicon.ico"
     }
     link: {
       label: "View Query History in BigQuery"
       url: "https://console.cloud.google.com/bigquery?j=bq:@{REGION}:{{ value | uri_encode }}&page=queryresults"
-      icon_url: "https://www.gstatic.com/devrel-devsite/prod/vb06d4bce6b32c84cf01c36dffa546f7ea4ff7fc8fcd295737b014c1412e4d118/cloud/images/favicons/onecloud/favicon.ico"
+      icon_url: "https://cloud.google.com/favicon.ico"
     }
     #LAMS
     #rule_exemptions:{F1:"The performance benefit of linking to a date-filterd dashboard is significant, and we can ensure that the date view is always available to prevent errors"}
@@ -107,7 +107,7 @@ view: jobs_base {
 #     link: {
 #       label: "User Lookup Dashboard"
 #       url: "/dashboards/...?User={{ value | uri_encode }}"
-#       icon_url: "http://www.looker.com/favicon.ico"
+#       icon_url: "/favicon.ico"
 #     }
   }
 
@@ -431,7 +431,8 @@ view: jobs_base {
 
   dimension: query_raw {
     hidden: yes
-    sql: ${TABLE}.query ;;
+    sql: {%if "@{PII_QUERY_TEXT}" == "SHOW" %} ${TABLE}.query {%
+      else %} REGEXP_REPLACE(REGEXP_REPLACE(${TABLE}.query, r"""'(\\.|[^'\\])+('|$)|"(\\.|[^"\\])+("|$)""", "[Redacted string]"), "[0-9][0-9][0-9][0-9]+", "[Redacted int]") {% endif %};;
   }
 
   dimension: query_text {

--- a/views/jobs/jobs.view.lkml
+++ b/views/jobs/jobs.view.lkml
@@ -59,6 +59,8 @@ view: jobs_base {
       url: "https://console.cloud.google.com/bigquery?j=bq:@{REGION}:{{ value | uri_encode }}&page=queryresults"
       icon_url: "https://www.gstatic.com/devrel-devsite/prod/vb06d4bce6b32c84cf01c36dffa546f7ea4ff7fc8fcd295737b014c1412e4d118/cloud/images/favicons/onecloud/favicon.ico"
     }
+    #LAMS
+    #rule_exemptions:{F1:"The performance benefit of linking to a date-filterd dashboard is significant, and we can ensure that the date view is always available to prevent errors"}
   }
 
   dimension_group: creation {

--- a/views/jobs_timeline/jobs_timeline.view.lkml
+++ b/views/jobs_timeline/jobs_timeline.view.lkml
@@ -61,12 +61,12 @@ view: jobs_timeline_base {
     link: {
       label: "Job Lookup Dashboard"
       url: "/dashboards-next/bigquery_information_schema::job_lookup_dashboard?Job%20ID={{ value | encode_uri}}&Created={{date.date_in_filter_format | encode_uri}}"
-      icon_url: "http://www.looker.com/favicon.ico"
+      icon_url: "/favicon.ico"
     }
     link: {
       label: "View Query History in BigQuery"
       url: "https://console.cloud.google.com/bigquery?j=bq:@{REGION}:{{ value }}&page=queryresults"
-      icon_url: "http://www.looker.com/favicon.ico"
+      icon_url: "https://cloud.google.com/favicon.ico"
     }
     #LAMS
     #rule_exemptions:{F1:"The performance benefit of linking to a date-filterd dashboard is significant, and we can ensure that the date view is always available to prevent errors"}

--- a/views/jobs_timeline/jobs_timeline.view.lkml
+++ b/views/jobs_timeline/jobs_timeline.view.lkml
@@ -50,6 +50,10 @@ view: jobs_timeline_base {
 
 
   #Primary key is (job_id, period_start)
+
+  #LAMS
+  #rule_exemptions: {K7: "Although this view does have a composite primary key, we will likely never want to use it as this should never be on the 'one' side of a join, nor sym-agg'd"}
+
   dimension: job_id {
     hidden: yes # More intuitive to show as the PK in the job view than as a FK in the timeline view
     type: string
@@ -64,6 +68,8 @@ view: jobs_timeline_base {
       url: "https://console.cloud.google.com/bigquery?j=bq:@{REGION}:{{ value }}&page=queryresults"
       icon_url: "http://www.looker.com/favicon.ico"
     }
+    #LAMS
+    #rule_exemptions:{F1:"The performance benefit of linking to a date-filterd dashboard is significant, and we can ensure that the date view is always available to prevent errors"}
   }
 
   dimension_group: period_start {
@@ -134,10 +140,7 @@ view: jobs_timeline_base {
     sql: ${TABLE}.state ;;
   }
 
-
-
   # Measure Group: Job Seconds {
-
 
   measure: job_seconds {
     group_label: "Job Seconds"
@@ -146,6 +149,7 @@ view: jobs_timeline_base {
     type: count
     value_format_name: decimal_0
     drill_fields: [detail*]
+    filters: [job_id: "-NULL"]
   }
 
   measure: job_seconds_running {

--- a/views/jobs_timeline/jobs_timeline_job.view.lkml
+++ b/views/jobs_timeline/jobs_timeline_job.view.lkml
@@ -15,12 +15,12 @@ view: jobs_timeline_job {
     link: {
       label: "Job Lookup Dashboard"
       url: "/dashboards-next/bigquery_information_schema::job_lookup_dashboard?Job%20ID={{ value | encode_uri}}&Created={{date.date_in_filter_format | encode_uri}}"
-      icon_url: "http://www.looker.com/favicon.ico"
+      icon_url: "/favicon.ico"
     }
     link: {
       label: "View Query History in BigQuery"
       url: "https://console.cloud.google.com/bigquery?j=bq:@{REGION}:{{ value }}&page=queryresults"
-      icon_url: "http://www.looker.com/favicon.ico"
+      icon_url: "https://cloud.google.com/favicon.ico"
     }
   }
 

--- a/views/tables.view.lkml
+++ b/views/tables.view.lkml
@@ -7,6 +7,7 @@ view: tables {
   measure: count {
     type: count
     drill_fields: [detail*]
+    filters: [table_name: "-NULL"]
   }
 
   # Dimension group: identifiers {


### PR DESCRIPTION
This PR adds the following:

- Linting via LAMS linter
   - Custom rules to ensure published manifest values aren't unintentionally changes
   - Small updates to existing block LookML to conform with the selected rules from the style guide
 - Support for BI Engine stats/data
 - Ability to redact strings and numbers from query text / query plans to reduce PII risks
   - New constant to control whether this is applied
 - Fixing removal of performance-related filter from PR#4
